### PR TITLE
Reverted back SSL_MAX_CERT_LIST_DEFAULT value since large algs are gone

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -4252,10 +4252,7 @@ OPENSSL_EXPORT int SSL_total_renegotiations(const SSL *ssl);
 
 // SSL_MAX_CERT_LIST_DEFAULT is the default maximum length, in bytes, of a peer
 // certificate chain.
-// OQS note: To accomodate signature schemes such as Rainbow,
-// we have changed this from (1024 * 100) to 2^(24) - 1, which
-// is the maximum permissible value established by the TLS 1.3 spec.
-#define SSL_MAX_CERT_LIST_DEFAULT 16777215
+#define SSL_MAX_CERT_LIST_DEFAULT (1024 * 100)
 
 // SSL_CTX_get_max_cert_list returns the maximum length, in bytes, of a peer
 // certificate chain accepted by |ctx|.


### PR DESCRIPTION
The `SSL_MAX_CERT_LIST_DEFAULT` modification in [ssl.h](https://github.com/open-quantum-safe/boringssl/blob/master/include/openssl/ssl.h#L4253) is not needed anymore, since Rainbow is not in OQS anymore.

To-do after merge: update the [implementation notes](https://github.com/open-quantum-safe/boringssl/wiki/Implementation-Notes) wiki page.