### PR TITLE
Fix expired test cert failure

### DIFF
--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -8640,6 +8640,8 @@ RVHWbCvFvNZAoWiIJ2z34RLGInyZvCZ8xLAvsuaWULDDaoeDl1M0t4Hm
   SSL_CTX_set_verify(client_ctx.get(),
                      SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                      nullptr);
+  X509_VERIFY_PARAM_set_flags(SSL_CTX_get0_param(client_ctx.get()),
+                              X509_V_FLAG_NO_CHECK_TIME);
 
   struct TestCase {
     X509 *cert;

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2397,6 +2397,8 @@ XRqE7XFhHL+7TNC2a9OOAjQsEF137YPWo+rhgko=
   ASSERT_TRUE(X509_STORE_add_cert(store.get(), root.get()));
   SSL_CTX_set_cert_store(client_ctx.get(), store.release());
   SSL_CTX_set_verify(client_ctx.get(), SSL_VERIFY_PEER, nullptr);
+  X509_VERIFY_PARAM_set_flags(SSL_CTX_get0_param(client_ctx.get()),
+                              X509_V_FLAG_NO_CHECK_TIME);
   static const char kSecretName[] = "secret.example";
   ASSERT_TRUE(X509_VERIFY_PARAM_set1_host(SSL_CTX_get0_param(client_ctx.get()),
                                           kSecretName, strlen(kSecretName)));


### PR DESCRIPTION
Cherry-picked last two commits (see [history](https://github.com/google/boringssl/commits/master/ssl/ssl_test.cc)) on `ssl/ssl_test.cc` to fix an expired cert test failure. Fixes #93. 